### PR TITLE
Add YAML settings support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -20,6 +20,7 @@ from discord.ext.commands import Context
 from dotenv import load_dotenv
 
 from database import DatabaseManager
+from config import Settings
 
 load_dotenv()
 
@@ -137,6 +138,7 @@ class DiscordBot(commands.Bot):
         self.database = None
         self.bot_prefix = os.getenv("PREFIX")
         self.invite_link = os.getenv("INVITE_LINK")
+        self.settings: Settings | None = None
 
     async def init_db(self) -> None:
         async with aiosqlite.connect(
@@ -191,6 +193,7 @@ class DiscordBot(commands.Bot):
             f"Running on: {platform.system()} {platform.release()} ({os.name})"
         )
         self.logger.info("-------------------")
+        self.settings = Settings.from_yaml()
         await self.init_db()
         await self.load_cogs()
         self.status_task.start()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+race_frequency: 1
+default_wallet: 100
+retirement_threshold: 65

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    race_frequency: int
+    default_wallet: int
+    retirement_threshold: int
+
+    @classmethod
+    def from_yaml(cls, path: str | Path = Path("config.yaml")) -> "Settings":
+        data: dict[str, Any]
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return cls(**data)
+
+__all__ = ["Settings"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ aiohttp
 aiosqlite
 discord.py==2.5.2
 python-dotenv
+pydantic
+PyYAML


### PR DESCRIPTION
## Summary
- manage new configuration via `config.yaml`
- expose a `Settings` class for YAML-based settings
- load settings during bot startup
- include dependencies for new config loader

## Testing
- `python -m py_compile bot.py config/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68744141a6a48326bba4e41090ff6c55