### PR TITLE
Add Derby ORM tables and integrate

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -7,11 +7,13 @@ Version: 6.3.0
 """
 
 import aiosqlite
+from sqlalchemy.engine import Engine
 
 
 class DatabaseManager:
-    def __init__(self, *, connection: aiosqlite.Connection) -> None:
+    def __init__(self, *, connection: aiosqlite.Connection, engine: Engine) -> None:
         self.connection = connection
+        self.engine = engine
 
     async def add_warn(
         self, user_id: int, server_id: int, moderator_id: int, reason: str

--- a/derby/__init__.py
+++ b/derby/__init__.py
@@ -1,0 +1,11 @@
+from .models import Base, Racer, Race, Bet, Wallet, CourseSegment, GuildSettings
+
+__all__ = [
+    "Base",
+    "Racer",
+    "Race",
+    "Bet",
+    "Wallet",
+    "CourseSegment",
+    "GuildSettings",
+]

--- a/derby/models.py
+++ b/derby/models.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+
+
+class Racer(Base):
+    __tablename__ = "racers"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    owner_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    retired: Mapped[bool] = mapped_column(Boolean, default=False)
+
+
+class Race(Base):
+    __tablename__ = "races"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    finished: Mapped[bool] = mapped_column(Boolean, default=False)
+
+
+class Bet(Base):
+    __tablename__ = "bets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    race_id: Mapped[int] = mapped_column(ForeignKey("races.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    racer_id: Mapped[int] = mapped_column(ForeignKey("racers.id"), nullable=False)
+    amount: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class Wallet(Base):
+    __tablename__ = "wallets"
+
+    user_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    balance: Mapped[int] = mapped_column(Integer, default=0)
+
+
+class CourseSegment(Base):
+    __tablename__ = "course_segments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    race_id: Mapped[int] = mapped_column(ForeignKey("races.id"), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    description: Mapped[str] = mapped_column(String, default="")
+
+
+class GuildSettings(Base):
+    __tablename__ = "guild_settings"
+
+    guild_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    race_frequency: Mapped[int] = mapped_column(Integer, default=1)
+    default_wallet: Mapped[int] = mapped_column(Integer, default=100)
+    retirement_threshold: Mapped[int] = mapped_column(Integer, default=65)
+
+
+__all__ = [
+    "Base",
+    "Racer",
+    "Race",
+    "Bet",
+    "Wallet",
+    "CourseSegment",
+    "GuildSettings",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ discord.py==2.5.2
 python-dotenv
 pydantic
 PyYAML
+SQLAlchemy>=2


### PR DESCRIPTION
## Summary
- create new SQLAlchemy models for derby races
- initialize derby tables on startup
- provide database engine to `DatabaseManager`
- add SQLAlchemy dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874425759008326ba3fa77e1555c132