### PR TITLE
Add derby race scheduler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,17 +14,17 @@ import random
 import sys
 
 import aiosqlite
-from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
-
-from derby import Base
 import discord
 from discord.ext import commands, tasks
 from discord.ext.commands import Context
 from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 
-from database import DatabaseManager
 from config import Settings
+from database import DatabaseManager
+from derby import Base
+from derby.scheduler import DerbyScheduler
 
 load_dotenv()
 
@@ -143,6 +143,7 @@ class DiscordBot(commands.Bot):
         self.bot_prefix = os.getenv("PREFIX")
         self.invite_link = os.getenv("INVITE_LINK")
         self.settings: Settings | None = None
+        self.scheduler: DerbyScheduler | None = None
 
     async def init_db(self) -> Engine:
         db_path = f"{os.path.realpath(os.path.dirname(__file__))}/database/database.db"
@@ -210,6 +211,8 @@ class DiscordBot(commands.Bot):
             ),
             engine=engine,
         )
+        self.scheduler = DerbyScheduler(self)
+        await self.scheduler.start()
 
     async def on_message(self, message: discord.Message) -> None:
         """

--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import os
+import random
+from datetime import datetime
+
+import discord
+from discord.ext import tasks
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from . import Base, logic, models
+from . import repositories as repo
+
+
+class DerbyScheduler:
+    """Background task handling daily races."""
+
+    def __init__(self, bot: discord.Client, db_path: str | None = None) -> None:
+        self.bot = bot
+        root = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+        self.db_path = db_path or os.path.join(root, "database", "database.db")
+        self.engine = create_async_engine(f"sqlite+aiosqlite:///{self.db_path}")
+        self.sessionmaker = async_sessionmaker(self.engine, expire_on_commit=False)
+        self._initialized = False
+        self.task = tasks.loop(hours=24)(self._run)
+
+    async def start(self) -> None:
+        await self._init_db()
+        self.task.start()
+
+    async def close(self) -> None:
+        if self.task.is_running():
+            self.task.cancel()
+        await self.engine.dispose()
+
+    async def _init_db(self) -> None:
+        if self._initialized:
+            return
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self._initialized = True
+
+    async def _run(self) -> None:
+        await self.tick()
+
+    async def tick(self) -> None:
+        await self._init_db()
+        async with self.sessionmaker() as session:
+            await self._create_daily_races(session)
+            await self._start_ready_races(session)
+
+    async def _create_daily_races(self, session: AsyncSession) -> None:
+        now = datetime.utcnow()
+        start_of_day = datetime(now.year, now.month, now.day)
+        for guild in self.bot.guilds:
+            result = await session.execute(
+                select(func.count(models.Race.id)).where(
+                    models.Race.guild_id == guild.id,
+                    models.Race.started_at >= start_of_day,
+                )
+            )
+            count = result.scalar_one()
+            needed = self.bot.settings.race_frequency - count
+            for _ in range(max(0, needed)):
+                await repo.create_race(session, guild_id=guild.id)
+
+    async def _start_ready_races(self, session: AsyncSession) -> None:
+        result = await session.execute(
+            select(models.Race).where(models.Race.finished.is_(False))
+        )
+        races = result.scalars().all()
+        if not races:
+            return
+
+        racers_result = await session.execute(
+            select(models.Racer).where(models.Racer.retired.is_(False))
+        )
+        racers = racers_result.scalars().all()
+        if not racers:
+            return
+
+        for race in races:
+            participants = random.sample(racers, min(3, len(racers)))
+            placements, _log = logic.simulate_race({"racers": participants}, race.id)
+            await repo.update_race(session, race.id, finished=True)
+            await logic.resolve_payouts(session, race.id)
+            await self._apply_retirements(session, participants)
+            await session.commit()
+            await self._post_results(race.guild_id, placements)
+
+    async def _post_results(self, guild_id: int, placements: list[int]) -> None:
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            return
+        channel = guild.system_channel or (
+            guild.text_channels[0] if guild.text_channels else None
+        )
+        if channel is None:
+            return
+        results = "\n".join(f"{i+1}. Racer {rid}" for i, rid in enumerate(placements))
+        await channel.send(f"Race Results:\n{results}")
+
+    async def _apply_retirements(
+        self, session: AsyncSession, racers: list[models.Racer]
+    ) -> None:
+        threshold = self.bot.settings.retirement_threshold
+        for racer in racers:
+            if random.randint(1, 100) >= threshold:
+                await repo.update_racer(session, racer.id, retired=True)
+                await repo.create_racer(
+                    session,
+                    name=f"{racer.name} II",
+                    owner_id=racer.owner_id,
+                )

--- a/tests/derby/test_scheduler.py
+++ b/tests/derby/test_scheduler.py
@@ -1,0 +1,77 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from config import Settings
+from derby import repositories as repo
+from derby.models import Race, Racer
+from derby.scheduler import DerbyScheduler
+
+
+class DummyChannel:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(self, content: str) -> None:
+        self.messages.append(content)
+
+
+class DummyGuild:
+    def __init__(self, gid: int) -> None:
+        self.id = gid
+        self.system_channel = DummyChannel()
+        self.text_channels = [self.system_channel]
+
+
+class DummyBot:
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.guilds: list[DummyGuild] = []
+        self.loop = asyncio.get_event_loop()
+
+    def get_guild(self, gid: int) -> DummyGuild | None:
+        for g in self.guilds:
+            if g.id == gid:
+                return g
+        return None
+
+
+@pytest.mark.asyncio
+async def test_scheduler_creates_and_runs_race(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    settings = Settings(race_frequency=1, default_wallet=100, retirement_threshold=101)
+    bot = DummyBot(settings)
+    guild = DummyGuild(1)
+    bot.guilds.append(guild)
+
+    scheduler = DerbyScheduler(bot, db_path=str(db_path))
+    await scheduler.tick()
+
+    async with scheduler.sessionmaker() as session:
+        await repo.create_racer(session, name="A", owner_id=1)
+        await repo.create_racer(session, name="B", owner_id=2)
+        await scheduler.tick()
+        races = (await session.execute(select(Race))).scalars().all()
+        assert len(races) == 1 and races[0].finished
+
+
+@pytest.mark.asyncio
+async def test_retirement(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    settings = Settings(race_frequency=1, default_wallet=100, retirement_threshold=0)
+    bot = DummyBot(settings)
+    guild = DummyGuild(1)
+    bot.guilds.append(guild)
+
+    scheduler = DerbyScheduler(bot, db_path=str(db_path))
+    async with scheduler.sessionmaker() as session:
+        await repo.create_racer(session, name="A", owner_id=1)
+        await repo.create_racer(session, name="B", owner_id=2)
+    await scheduler.tick()
+
+    async with scheduler.sessionmaker() as session:
+        racers = (await session.execute(select(Racer))).scalars().all()
+        retired = [r for r in racers if r.retired]
+        assert retired and len(racers) == 4


### PR DESCRIPTION
## Summary
- schedule daily races with DerbyScheduler
- wire scheduler into the bot
- test scheduler basics

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not install deps)*
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68744b95b59483269a410f750a9b6f07