### PR TITLE
Add wallet command

### DIFF
--- a/cogs/derby.py
+++ b/cogs/derby.py
@@ -61,6 +61,19 @@ class Derby(commands.Cog, name="derby"):
     def __init__(self, bot) -> None:
         self.bot = bot
 
+    @commands.hybrid_command(name="wallet", description="Show your wallet balance")
+    async def wallet(self, context: Context) -> None:
+        async with self.bot.scheduler.sessionmaker() as session:
+            wallet = await repo.get_wallet(session, context.author.id)
+            if wallet is None:
+                wallet = await repo.create_wallet(
+                    session,
+                    user_id=context.author.id,
+                    balance=self.bot.settings.default_wallet,
+                )
+            balance = wallet.balance
+        await context.send(f"Your balance is {balance} coins")
+
     @commands.hybrid_group(name="race", description="Race commands")
     async def race(
         self, context: Context

--- a/tests/test_derby_cog.py
+++ b/tests/test_derby_cog.py
@@ -12,8 +12,9 @@ from derby import repositories as repo
 
 
 class DummyContext:
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot, author_id: int = 1) -> None:
         self.bot = bot
+        self.author = types.SimpleNamespace(id=author_id)
         self.sent: list[dict[str, object]] = []
 
     async def send(self, content: str | None = None, **kwargs) -> None:
@@ -49,3 +50,23 @@ async def test_race_upcoming(tmp_path: Path) -> None:
     assert ctx.sent and ctx.sent[0]["embed"].title == "Upcoming Race"
     fields = ctx.sent[0]["embed"].fields
     assert fields[0].name == "Race ID" and fields[0].value == str(race.id)
+
+
+@pytest.mark.asyncio
+async def test_wallet_creates_and_shows_balance(tmp_path: Path) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path/'db.sqlite'}")
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    bot.settings = Settings(
+        race_frequency=1, default_wallet=50, retirement_threshold=65
+    )
+    bot.scheduler = types.SimpleNamespace(sessionmaker=sessionmaker)
+    cog = derby_cog.Derby(bot)
+    ctx = DummyContext(bot, author_id=42)
+
+    await cog.wallet(ctx)
+
+    assert ctx.sent and ctx.sent[0]["content"] == "Your balance is 50 coins"
+    async with sessionmaker() as session:
+        wallet = await repo.get_wallet(session, 42)
+        assert wallet is not None and wallet.balance == 50


### PR DESCRIPTION
## Summary
- add `/wallet` command to show your current balance
- automatically create wallets with the guild's default amount
- test new wallet command

## Testing
- `python -m pip install -r requirements.txt` *(fails: cannot access internet)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68745e2812d08326b774bec4e08a98bb