### PR TITLE
Stream derby commentary

### DIFF
--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import random
 from datetime import datetime
@@ -24,6 +25,7 @@ class DerbyScheduler:
         self.sessionmaker = async_sessionmaker(self.engine, expire_on_commit=False)
         self._initialized = False
         self.task = tasks.loop(hours=24)(self._run)
+        self.commentaries: dict[int, tasks.Loop] = {}
 
     async def start(self) -> None:
         await self._init_db()
@@ -101,11 +103,12 @@ class DerbyScheduler:
 
         for race in races:
             participants = random.sample(racers, min(3, len(racers)))
-            placements, _log = logic.simulate_race({"racers": participants}, race.id)
+            placements, log = logic.simulate_race({"racers": participants}, race.id)
             await repo.update_race(session, race.id, finished=True)
             await logic.resolve_payouts(session, race.id)
             await self._apply_retirements(session, participants)
             await session.commit()
+            await self._stream_commentary(race.id, race.guild_id, log)
             await self._post_results(race.guild_id, placements)
 
     async def _post_results(self, guild_id: int, placements: list[int]) -> None:
@@ -119,6 +122,55 @@ class DerbyScheduler:
             return
         results = "\n".join(f"{i+1}. Racer {rid}" for i, rid in enumerate(placements))
         await channel.send(f"Race Results:\n{results}")
+
+    async def _stream_commentary(
+        self, race_id: int, guild_id: int, log: list[str], delay: float = 2.0
+    ) -> None:
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            return
+        channel = guild.system_channel or (
+            guild.text_channels[0] if guild.text_channels else None
+        )
+        if channel is None:
+            return
+
+        events = iter(log)
+        done = asyncio.Event()
+        commentary: tasks.Loop | None = None
+
+        async def send_next() -> None:
+            nonlocal commentary
+            async with self.sessionmaker() as session:
+                if await repo.get_race(session, race_id) is None:
+                    if commentary:
+                        commentary.cancel()
+                    done.set()
+                    return
+            try:
+                event = next(events)
+            except StopIteration:
+                if commentary:
+                    commentary.cancel()
+                done.set()
+                return
+            embed = discord.Embed(description=event)
+            try:
+                await channel.send(embed=embed)
+            except (discord.Forbidden, discord.HTTPException):
+                if commentary:
+                    commentary.cancel()
+                done.set()
+                return
+
+        commentary = tasks.Loop(send_next, seconds=delay)
+        await send_next()
+        if not done.is_set():
+            self.commentaries[race_id] = commentary
+            commentary.start()
+            await done.wait()
+            commentary.cancel()
+            self.commentaries.pop(race_id, None)
 
     async def _apply_retirements(
         self, session: AsyncSession, racers: list[models.Racer]

--- a/tests/derby/test_scheduler.py
+++ b/tests/derby/test_scheduler.py
@@ -1,6 +1,7 @@
 import asyncio
 from pathlib import Path
 
+import discord
 import pytest
 from sqlalchemy import select
 
@@ -14,8 +15,13 @@ class DummyChannel:
     def __init__(self) -> None:
         self.messages: list[str] = []
 
-    async def send(self, content: str) -> None:
-        self.messages.append(content)
+    async def send(
+        self, content: str | None = None, *, embed: discord.Embed | None = None
+    ) -> None:
+        if embed is not None and embed.description is not None:
+            self.messages.append(embed.description)
+        elif content is not None:
+            self.messages.append(content)
 
 
 class DummyGuild:
@@ -75,3 +81,48 @@ async def test_retirement(tmp_path: Path) -> None:
         racers = (await session.execute(select(Racer))).scalars().all()
         retired = [r for r in racers if r.retired]
         assert retired and len(racers) == 4
+
+
+@pytest.mark.asyncio
+async def test_stream_commentary(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    settings = Settings(race_frequency=1, default_wallet=100, retirement_threshold=101)
+    bot = DummyBot(settings)
+    guild = DummyGuild(1)
+    bot.guilds.append(guild)
+
+    scheduler = DerbyScheduler(bot, db_path=str(db_path))
+    await scheduler._init_db()
+    async with scheduler.sessionmaker() as session:
+        race = await repo.create_race(session, guild_id=guild.id)
+
+    events = ["E1", "E2", "E3"]
+    await scheduler._stream_commentary(race.id, guild.id, events, delay=0)
+    assert guild.system_channel.messages == events
+
+
+@pytest.mark.asyncio
+async def test_commentary_stops_when_cancelled(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    settings = Settings(race_frequency=1, default_wallet=100, retirement_threshold=101)
+    bot = DummyBot(settings)
+    guild = DummyGuild(1)
+    bot.guilds.append(guild)
+
+    scheduler = DerbyScheduler(bot, db_path=str(db_path))
+    await scheduler._init_db()
+    async with scheduler.sessionmaker() as session:
+        race = await repo.create_race(session, guild_id=guild.id)
+
+    events = ["A", "B", "C"]
+
+    async def cancel() -> None:
+        await asyncio.sleep(0.01)
+        async with scheduler.sessionmaker() as session:
+            await repo.delete_race(session, race.id)
+
+    cancel_task = asyncio.create_task(cancel())
+    await scheduler._stream_commentary(race.id, guild.id, events, delay=0.05)
+    await cancel_task
+
+    assert len(guild.system_channel.messages) == 1


### PR DESCRIPTION
## Summary
- stream commentary events using `discord.ext.tasks`
- throttle commentary updates and stop gracefully on cancellation
- test streaming logic with dummy Discord channel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6874753156c48326bb01bfec80479b63