### PR TITLE
Implement payout DMs and leaderboard embed

### DIFF
--- a/tests/derby/test_scheduler.py
+++ b/tests/derby/test_scheduler.py
@@ -35,6 +35,7 @@ class DummyBot:
     def __init__(self, settings: Settings) -> None:
         self.settings = settings
         self.guilds: list[DummyGuild] = []
+        self.users: dict[int, DummyUser] = {}
         self.loop = asyncio.get_event_loop()
 
     def get_guild(self, gid: int) -> DummyGuild | None:
@@ -42,6 +43,18 @@ class DummyBot:
             if g.id == gid:
                 return g
         return None
+
+    def get_user(self, uid: int) -> "DummyUser | None":
+        return self.users.get(uid)
+
+
+class DummyUser:
+    def __init__(self, uid: int) -> None:
+        self.id = uid
+        self.dms: list[dict[str, object]] = []
+
+    async def send(self, content: str | None = None, **kwargs) -> None:
+        self.dms.append({"content": content, **kwargs})
 
 
 @pytest.mark.asyncio
@@ -126,3 +139,37 @@ async def test_commentary_stops_when_cancelled(tmp_path: Path) -> None:
     await cancel_task
 
     assert len(guild.system_channel.messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_payout_dm_sent(tmp_path: Path) -> None:
+    db_path = tmp_path / "db.sqlite"
+    settings = Settings(race_frequency=1, default_wallet=100, retirement_threshold=101)
+    bot = DummyBot(settings)
+    guild = DummyGuild(1)
+    bot.guilds.append(guild)
+
+    user1 = DummyUser(10)
+    user2 = DummyUser(11)
+    bot.users[user1.id] = user1
+    bot.users[user2.id] = user2
+
+    scheduler = DerbyScheduler(bot, db_path=str(db_path))
+    await scheduler._init_db()
+    async with scheduler.sessionmaker() as session:
+        race = await repo.create_race(session, guild_id=guild.id)
+        r1 = await repo.create_racer(session, name="A", owner_id=1)
+        r2 = await repo.create_racer(session, name="B", owner_id=2)
+        await repo.create_wallet(session, user_id=user1.id, balance=100)
+        await repo.create_wallet(session, user_id=user2.id, balance=100)
+        await repo.create_bet(
+            session, race_id=race.id, user_id=user1.id, racer_id=r1.id, amount=10
+        )
+        await repo.create_bet(
+            session, race_id=race.id, user_id=user2.id, racer_id=r2.id, amount=20
+        )
+
+    await scheduler.tick()
+
+    assert len(user1.dms) == 1
+    assert len(user2.dms) == 1


### PR DESCRIPTION
## Summary
- DM bettors about their winnings or losses after payouts
- Display race results via embed leaderboard
- test payout notifications

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68747bab743c832695f568f43a213414