### PR TITLE
Fix stray f-string and remove unused imports

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,6 @@ import logging
 import os
 import platform
 import random
-import sys
 from datetime import datetime
 
 import aiosqlite

--- a/checks.py
+++ b/checks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import discord
 from discord.ext import commands
 
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -211,7 +211,7 @@ class General(commands.Cog, name="general"):
         :param context: The hybrid command context.
         """
         embed = discord.Embed(
-            description=f"Join the support server for the bot by clicking [here](https://discord.gg/mTBrXyWxAF).",
+            description="Join the support server for the bot by clicking [here](https://discord.gg/mTBrXyWxAF).",
             color=0xD75BF4,
         )
         try:

--- a/derby/logic.py
+++ b/derby/logic.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import random
-from typing import Iterable, Sequence, Tuple, Dict, List
+from typing import Dict, List, Sequence, Tuple
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import models
 
@@ -50,7 +50,9 @@ def simulate_race(
         racers = [r.id if hasattr(r, "id") else int(r) for r in race.get("racers", [])]
         segments = race.get("course_segments", [])
     else:
-        racers = [r.id if hasattr(r, "id") else int(r) for r in getattr(race, "racers", [])]
+        racers = [
+            r.id if hasattr(r, "id") else int(r) for r in getattr(race, "racers", [])
+        ]
         segments = getattr(race, "course_segments", [])
 
     placements = list(racers)


### PR DESCRIPTION
## Summary
- trim stray import statements flagged by Ruff
- remove unnecessary f-string prefix for server invite link

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6874881b36488326b95fddb9c981ed6e