### PR TITLE
Remove invalid ephemeral arg from DM

### DIFF
--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -173,7 +173,7 @@ class DerbyScheduler:
             else:
                 msg = f"You lost your bet of {bet.amount} coins on race {race_id}."
             try:
-                await user.send(msg, ephemeral=True)
+                await user.send(msg)
             except (discord.Forbidden, discord.HTTPException):
                 continue
 


### PR DESCRIPTION
## Summary
- remove `ephemeral=True` when sending payout DMs in the scheduler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6874882d0d48832692411106e807696d