### PR TITLE
Refactor wallet balance test setup

### DIFF
--- a/tests/test_derby_cog.py
+++ b/tests/test_derby_cog.py
@@ -113,7 +113,17 @@ async def test_admin_check_requires_role(tmp_path: Path) -> None:
         await cog.add_racer.can_run(ctx)  # type: ignore[arg-type]
 
 
+@pytest.mark.asyncio
 async def test_wallet_command_creates_and_returns_balance(tmp_path: Path) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path/'db.sqlite'}")
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    bot.settings = Settings(
+        race_frequency=1, default_wallet=100, retirement_threshold=65
+    )
+    bot.scheduler = types.SimpleNamespace(sessionmaker=sessionmaker)
+    cog = derby_cog.Derby(bot)
+    ctx = DummyContext(bot)
     ctx.author = types.SimpleNamespace(id=10)
 
     await cog.wallet(ctx)


### PR DESCRIPTION
## Summary
- initialize bot and context inside `test_wallet_command_creates_and_returns_balance`
- mark the test with `@pytest.mark.asyncio`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_68748833e5c48326bdd4d569b21e52cb