### PR TITLE
Fix DB initialization bug

### DIFF
--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -41,7 +41,7 @@ class DerbyScheduler:
             return
         async with self.engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-            inspector = inspect(conn.sync_connection())
+            inspector = inspect(conn.sync_connection)
             columns = {c["name"] for c in inspector.get_columns("racers")}
             new_columns = {
                 "speed": "INTEGER",


### PR DESCRIPTION
## Summary
- fix incorrect call to `sync_connection` when initializing database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and discord)*
- `pip install -r requirements.txt` *(fails due to blocked internet)*

------
https://chatgpt.com/codex/tasks/task_e_687492ac61588326b96200580b152d0e