### PR TITLE
Fix scheduler DB init with async inspector

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -19,4 +19,5 @@ class Settings(BaseSettings):
             data = yaml.safe_load(f) or {}
         return cls(**data)
 
+
 __all__ = ["Settings"]

--- a/derby/__init__.py
+++ b/derby/__init__.py
@@ -1,4 +1,4 @@
-from .models import Base, Racer, Race, Bet, Wallet, CourseSegment, GuildSettings
+from .models import Base, Bet, CourseSegment, GuildSettings, Race, Racer, Wallet
 
 __all__ = [
     "Base",

--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import random
 from datetime import datetime
+from typing import Any
 
 import discord
 from discord.ext import tasks
@@ -41,8 +42,12 @@ class DerbyScheduler:
             return
         async with self.engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-            inspector = inspect(conn.sync_connection)
-            columns = {c["name"] for c in inspector.get_columns("racers")}
+
+            def get_columns(sync_conn: Any) -> set[str]:
+                inspector = inspect(sync_conn)
+                return {c["name"] for c in inspector.get_columns("racers")}
+
+            columns = await conn.run_sync(get_columns)
             new_columns = {
                 "speed": "INTEGER",
                 "cornering": "INTEGER",

--- a/tests/derby/test_logic.py
+++ b/tests/derby/test_logic.py
@@ -1,9 +1,9 @@
 import pytest
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from derby.models import Base, Racer, Race, Bet, Wallet
-from derby.logic import calculate_odds, simulate_race, resolve_payouts
+from derby.logic import calculate_odds, resolve_payouts, simulate_race
+from derby.models import Base, Bet, Race, Racer, Wallet
 
 
 @pytest.fixture()
@@ -47,10 +47,12 @@ async def test_resolve_payouts(session: AsyncSession):
     await session.commit()
     await session.refresh(race)
 
-    session.add_all([
-        Bet(race_id=race.id, user_id=1, racer_id=r1.id, amount=10),
-        Bet(race_id=race.id, user_id=2, racer_id=r2.id, amount=20),
-    ])
+    session.add_all(
+        [
+            Bet(race_id=race.id, user_id=1, racer_id=r1.id, amount=10),
+            Bet(race_id=race.id, user_id=2, racer_id=r2.id, amount=20),
+        ]
+    )
     session.add(Wallet(user_id=1, balance=50))
     await session.commit()
 


### PR DESCRIPTION
## Summary
- handle `get_columns` via `run_sync` in scheduler
- maintain formatting across project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687494e71158832691a2636bc9e70513