### PR TITLE
Add downtime derby admin and player docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ docker compose up -d --build
 
 > **Note**: `-d` will make the container run in detached mode, so in the background.
 
+## Downtime Derby Mini-Game
+
+Downtime Derby is a lightweight racing game bundled with this template. All commands are provided as Discord slash commands.
+
+### Admin Guide
+
+- **Create racers** with `/derby add_racer <name> @owner`.
+- **Edit racers** using `/derby edit_racer <racer_id> <name>` or delete them with `/derby racer delete <racer_id>`.
+- **Start a race** immediately via `/derby start_race` or cancel the next one with `/derby cancel_race`.
+- **Force-run a pending race** using `/derby race force-start [race_id]`.
+- **Inspect races** for troubleshooting with `/derby debug race <race_id>`.
+
+### Player Guide
+
+- Check the next event with `/race next` or view odds using `/race upcoming`.
+- Place a bet: `/race bet <racer_id> <amount>`.
+- Start and watch the race with `/race watch`.
+- Look up details on a racer using `/race info <racer_id>`.
+- Review past results via `/race history [count]`.
+- See your balance at any time with `/wallet`.
+
 ## Issues or Questions
 
 If you have any issues or questions of how to code a specific command, you can:


### PR DESCRIPTION
## Summary
- document how to use the downtime derby mini-game

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874958f698483269fc95666214ab2fd