### PR TITLE
Handle derby permission failures

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -278,6 +278,12 @@ class DiscordBot(commands.Bot):
                 color=0xE02B2B,
             )
             await context.send(embed=embed, ephemeral=True)
+        elif isinstance(error, commands.CheckFailure):
+            embed = discord.Embed(
+                description="You don't have permission to do that!",
+                color=0xE02B2B,
+            )
+            await context.send(embed=embed, ephemeral=True)
         elif isinstance(error, commands.MissingRequiredArgument):
             embed = discord.Embed(
                 title="Error!",

--- a/tests/test_derby_cog.py
+++ b/tests/test_derby_cog.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from bot import DiscordBot
 from cogs import derby as derby_cog
 from config import Settings
 from derby import models
@@ -243,3 +244,14 @@ async def test_race_history(tmp_path: Path) -> None:
     field = embed.fields[0]
     assert f"Race {race.id}" == field.name
     assert "A" in field.value and "30" in field.value
+
+
+@pytest.mark.asyncio
+async def test_on_command_error_check_failure() -> None:
+    bot = DiscordBot()
+    ctx = DummyContext(bot)
+
+    await bot.on_command_error(ctx, commands.CheckFailure())
+
+    assert ctx.sent
+    assert "permission" in ctx.sent[0]["embed"].description


### PR DESCRIPTION
## Summary
- add a CheckFailure branch in `on_command_error`
- test that the bot responds to missing permissions

## Testing
- `python -m pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68749adfcc68832681b93e330b7242fc