### PR TITLE
Fix tasks.Loop invocation

### DIFF
--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -225,7 +225,7 @@ class DerbyScheduler:
                 done.set()
                 return
 
-        commentary = tasks.Loop(send_next, seconds=delay)
+        commentary = tasks.loop(seconds=delay)(send_next)
         await send_next()
         if not done.is_set():
             self.commentaries[race_id] = commentary


### PR DESCRIPTION
## Summary
- fix scheduler to construct commentary loop using `tasks.loop`

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68754c9fa5f88326aa41d55bcd13c8f1