### PR TITLE
Add temperament and mood stats

### DIFF
--- a/cogs/derby.py
+++ b/cogs/derby.py
@@ -232,9 +232,7 @@ class Derby(commands.Cog, name="derby"):
         embed.add_field(
             name="Stamina", value=_stat_band(racer_obj.stamina), inline=True
         )
-        embed.add_field(
-            name="Temperament", value=_stat_band(racer_obj.temperament), inline=True
-        )
+        embed.add_field(name="Temperament", value=racer_obj.temperament, inline=True)
         embed.add_field(name="Mood", value=str(racer_obj.mood), inline=True)
         embed.add_field(
             name="Injuries", value=racer_obj.injuries or "None", inline=False
@@ -270,7 +268,7 @@ class Derby(commands.Cog, name="derby"):
         speed="Speed stat",
         cornering="Cornering stat",
         stamina="Stamina stat",
-        temperament="Temperament stat",
+        temperament="Temperament",
     )
     async def add_racer(
         self,
@@ -281,21 +279,21 @@ class Derby(commands.Cog, name="derby"):
         speed: app_commands.Range[int, 0, 31] | None = None,
         cornering: app_commands.Range[int, 0, 31] | None = None,
         stamina: app_commands.Range[int, 0, 31] | None = None,
-        temperament: app_commands.Range[int, 0, 31] | None = None,
+        temperament: str | None = None,
     ) -> None:
         if random_stats:
             stats = {
                 "speed": random.randint(0, 31),
                 "cornering": random.randint(0, 31),
                 "stamina": random.randint(0, 31),
-                "temperament": random.randint(0, 31),
+                "temperament": random.choice(list(logic.TEMPERAMENTS)),
             }
         else:
             stats = {
                 "speed": speed or 0,
                 "cornering": cornering or 0,
                 "stamina": stamina or 0,
-                "temperament": temperament or 0,
+                "temperament": temperament or "Quirky",
             }
         async with self.bot.scheduler.sessionmaker() as session:
             racer = await repo.create_racer(
@@ -311,7 +309,7 @@ class Derby(commands.Cog, name="derby"):
         speed="Speed stat",
         cornering="Cornering stat",
         stamina="Stamina stat",
-        temperament="Temperament stat",
+        temperament="Temperament",
     )
     async def edit_racer(
         self,
@@ -321,7 +319,7 @@ class Derby(commands.Cog, name="derby"):
         speed: app_commands.Range[int, 0, 31] | None = None,
         cornering: app_commands.Range[int, 0, 31] | None = None,
         stamina: app_commands.Range[int, 0, 31] | None = None,
-        temperament: app_commands.Range[int, 0, 31] | None = None,
+        temperament: str | None = None,
     ) -> None:
         updates: dict[str, int | str] = {}
         if name is not None:

--- a/derby/logic.py
+++ b/derby/logic.py
@@ -10,6 +10,42 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import models
 
+TEMPERAMENTS = {
+    "Agile": {"up": "speed", "down": "stamina"},
+    "Reckless": {"up": "speed", "down": "cornering"},
+    "Tactical": {"up": "cornering", "down": "speed"},
+    "Burly": {"up": "stamina", "down": "cornering"},
+    "Steady": {"up": "stamina", "down": "speed"},
+    "Sharpshift": {"up": "cornering", "down": "stamina"},
+    "Quirky": {"up": None, "down": None},
+}
+
+TEMPERAMENT_MODIFIER = 0.1
+
+
+def apply_temperament(
+    stats: Dict[str, int], temperament: str, modifier: float = TEMPERAMENT_MODIFIER
+) -> Dict[str, int]:
+    """Return ``stats`` adjusted for ``temperament``.
+
+    ``modifier`` is the percentage bonus or penalty applied to the affected
+    statistics. Unknown temperaments return stats unchanged.
+    """
+
+    result = stats.copy()
+    t = TEMPERAMENTS.get(temperament)
+    if not t:
+        return result
+
+    up = t.get("up")
+    down = t.get("down")
+
+    if up is not None:
+        result[up] = int(round(result[up] * (1 + modifier)))
+    if down is not None:
+        result[down] = int(round(result[down] * (1 - modifier)))
+    return result
+
 
 def calculate_odds(
     racers: Sequence[models.Racer] | Sequence[int],

--- a/derby/models.py
+++ b/derby/models.py
@@ -20,8 +20,8 @@ class Racer(Base):
     speed: Mapped[int] = mapped_column(Integer, default=0)
     cornering: Mapped[int] = mapped_column(Integer, default=0)
     stamina: Mapped[int] = mapped_column(Integer, default=0)
-    temperament: Mapped[int] = mapped_column(Integer, default=0)
-    mood: Mapped[int] = mapped_column(Integer, default=0)
+    temperament: Mapped[str] = mapped_column(String, default="Quirky")
+    mood: Mapped[int] = mapped_column(Integer, default=3)
     injuries: Mapped[str] = mapped_column(String, default="")
 
 

--- a/derby/repositories.py
+++ b/derby/repositories.py
@@ -55,8 +55,8 @@ async def create_racer(
     speed: int = 0,
     cornering: int = 0,
     stamina: int = 0,
-    temperament: int = 0,
-    mood: int = 0,
+    temperament: str = "Quirky",
+    mood: int = 3,
     injuries: str = "",
 ) -> Racer:
     return await _create(

--- a/derby/scheduler.py
+++ b/derby/scheduler.py
@@ -60,20 +60,18 @@ class DerbyScheduler:
 
             columns = await conn.run_sync(get_columns)
             new_columns = {
-                "speed": "INTEGER",
-                "cornering": "INTEGER",
-                "stamina": "INTEGER",
-                "temperament": "INTEGER",
-                "mood": "INTEGER",
-                "injuries": "VARCHAR",
+                "speed": ("INTEGER", "0"),
+                "cornering": ("INTEGER", "0"),
+                "stamina": ("INTEGER", "0"),
+                "temperament": ("VARCHAR", "'Quirky'"),
+                "mood": ("INTEGER", "3"),
+                "injuries": ("VARCHAR", "''"),
             }
-            for name, col_type in new_columns.items():
+            for name, (col_type, default) in new_columns.items():
                 if name not in columns:
                     await conn.execute(
                         text(
-                            f"ALTER TABLE racers ADD COLUMN {name} {col_type} DEFAULT 0"
-                            if col_type == "INTEGER"
-                            else f"ALTER TABLE racers ADD COLUMN {name} {col_type} DEFAULT ''"
+                            f"ALTER TABLE racers ADD COLUMN {name} {col_type} DEFAULT {default}"
                         )
                     )
         self._initialized = True

--- a/tests/derby/test_logic.py
+++ b/tests/derby/test_logic.py
@@ -2,7 +2,12 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from derby.logic import calculate_odds, resolve_payouts, simulate_race
+from derby.logic import (
+    apply_temperament,
+    calculate_odds,
+    resolve_payouts,
+    simulate_race,
+)
 from derby.models import Base, Bet, Race, Racer, Wallet
 
 
@@ -31,6 +36,13 @@ def test_simulate_race():
         "Segment 1: Racer 3 takes the lead",
         "Segment 2: Racer 2 takes the lead",
     ]
+
+
+def test_apply_temperament() -> None:
+    stats = {"speed": 10, "cornering": 10, "stamina": 10}
+    result = apply_temperament(stats, "Agile", 0.1)
+    assert result["speed"] == 11
+    assert result["stamina"] == 9
 
 
 @pytest.mark.asyncio

--- a/tests/derby/test_repositories.py
+++ b/tests/derby/test_repositories.py
@@ -25,7 +25,7 @@ async def test_racer_crud(session: AsyncSession):
         speed=5,
         cornering=6,
         stamina=7,
-        temperament=8,
+        temperament="Agile",
         mood=2,
         injuries="sprained ankle",
     )
@@ -36,7 +36,7 @@ async def test_racer_crud(session: AsyncSession):
     assert fetched.speed == 5
     assert fetched.cornering == 6
     assert fetched.stamina == 7
-    assert fetched.temperament == 8
+    assert fetched.temperament == "Agile"
     assert fetched.mood == 2
     assert fetched.injuries == "sprained ankle"
 

--- a/tests/test_derby_cog.py
+++ b/tests/test_derby_cog.py
@@ -314,14 +314,14 @@ async def test_add_racer_with_stats(tmp_path: Path) -> None:
         speed=20,
         cornering=21,
         stamina=22,
-        temperament=23,
+        temperament="Agile",
     )
 
     async with sessionmaker() as session:
         racer = (await session.execute(select(models.Racer))).scalars().first()
 
     assert racer.speed == 20 and racer.cornering == 21
-    assert racer.stamina == 22 and racer.temperament == 23
+    assert racer.stamina == 22 and racer.temperament == "Agile"
 
 
 @pytest.mark.asyncio
@@ -341,7 +341,9 @@ async def test_add_racer_random_stats(tmp_path: Path) -> None:
     ctx = DummyContext(bot)
     owner = types.SimpleNamespace(id=99)
 
-    with patch("random.randint", side_effect=[1, 2, 3, 4]):
+    with patch("random.randint", side_effect=[1, 2, 3]), patch(
+        "random.choice", return_value="Burly"
+    ):
         await cog.add_racer(ctx, name="Lucky", owner=owner, random_stats=True)
 
     async with sessionmaker() as session:
@@ -351,7 +353,7 @@ async def test_add_racer_random_stats(tmp_path: Path) -> None:
         1,
         2,
         3,
-        4,
+        "Burly",
     ]
 
 
@@ -406,11 +408,11 @@ async def test_race_info_bands(tmp_path: Path) -> None:
             speed=31,
             cornering=30,
             stamina=27,
-            temperament=10,
+            temperament="Reckless",
         )
 
     await cog.race_info(ctx, racer=racer.id)
 
     embed = ctx.sent[-1]["embed"]
     values = [f.value for f in embed.fields[:4]]
-    assert values == ["Perfect", "Fantastic", "Very Good", "Decent"]
+    assert values == ["Perfect", "Fantastic", "Very Good", "Reckless"]


### PR DESCRIPTION
## Summary
- support temperament modifiers with configurable bonus
- track mood from 1-5 on racers
- adjust database defaults and CRUD helpers
- update commands and tests for new temperament strings

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68755849215c832681787b851ac05df0